### PR TITLE
스크린 컴포넌트 3개로 분할

### DIFF
--- a/src/navigations/Tab.js
+++ b/src/navigations/Tab.js
@@ -1,6 +1,9 @@
 import React from "react";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { Calender, Chat, Lens } from "../screens/TabScreen";
+import { Calender } from "../screens/CalenderScreen";
+import { Chat } from "../screens/ChatScreen";
+import { Lens } from "../screens/LenScreen";
+//import { Calender, Chat, Lens } from "../screens/TabScreen";
 
 const Tab = createBottomTabNavigator();
 

--- a/src/screens/CalenderScreen.js
+++ b/src/screens/CalenderScreen.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components/native';
+
+const Container = styled.View`
+  flex: 1;
+  justify-content: center;
+  align=items: center;
+`;
+const StyledText = styled.Text`
+  font-size: 30px;
+`;
+
+export const Calender = () => {
+    return(
+        <Container>
+            <StyledText>Calender</StyledText>
+        </Container>
+    );
+};

--- a/src/screens/ChatScreen.js
+++ b/src/screens/ChatScreen.js
@@ -10,26 +10,10 @@ const StyledText = styled.Text`
   font-size: 30px;
 `;
 
-export const Calender = () => {
-    return(
-        <Container>
-            <StyledText>Mail</StyledText>
-        </Container>
-    );
-};
-
 export const Chat = () => {
     return(
         <Container>
             <StyledText>Chat</StyledText>
-        </Container>
-    );
-};
-
-export const Lens = () => {
-    return(
-        <Container>
-            <StyledText>Lens</StyledText>
         </Container>
     );
 };

--- a/src/screens/LenScreen.js
+++ b/src/screens/LenScreen.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components/native';
+
+const Container = styled.View`
+  flex: 1;
+  justify-content: center;
+  align=items: center;
+`;
+const StyledText = styled.Text`
+  font-size: 30px;
+`;
+
+export const Lens = () => {
+    return(
+        <Container>
+            <StyledText>Lens</StyledText>
+        </Container>
+    );
+};


### PR DESCRIPTION
기존에 TabScreen.js에 세 개의 스크린을 넣어 두고 export 하는 식으로 구현했는데 편의성을 위해
TabScreen.js을 삭제하고 CalenderScreen.js ChatScreen.js LensScreen.js 세 컴포넌트를 분할했습니다
각각 본인이 맡은 파트 스크린에서 작업해 주시면 감사하겠습니다~!!