### PR TITLE
ChatScreen으로 이동 시 하단 탭 안 보이도록

### DIFF
--- a/src/screens/RootStack.js
+++ b/src/screens/RootStack.js
@@ -1,11 +1,14 @@
 import React from "react";
 import {createStackNavigator} from '@react-navigation/stack';
 import TabNavigation from "./TabScreen";
+import {Chat} from "../screens/ChatScreen";
+
 // import CameraStackScreen from "./CameraStack";
 import RectangleScannerScreen from "../components/RectangleScannerScreen";
 
 const Stack = createStackNavigator();
 const CameraStack = createStackNavigator();
+const ChatStack = createStackNavigator();
 
 function RootStack(){
     return(
@@ -23,7 +26,20 @@ function RootStack(){
             options={({navigation, route}) => ({
                 headerShown: false,
               })}
+           /> 
+           <Stack.Screen
+            name = "ChatScreen"
+            component = {ChatStackScreen}
+            options = {({navigation, route}) => ({
+              headerShown: true,
+              headerTitleAlign: "center",
+              headerTitleStyle: {
+                fontSize: 15
+              },
+              headerTitle: "챗봇 이름",
+            })}
            />           
+
         </Stack.Navigator>
     )
 }
@@ -42,5 +58,21 @@ const CameraStackScreen = () => {
       </Stack.Navigator>
     )
   }
+
+  const ChatStackScreen = () => {
+    return(
+      <Stack.Navigator>
+        <ChatStack.Screen 
+          name = "Chat" 
+          component={Chat}
+          options = {(navigation, route)=> ({
+            headerShown: false,
+            headerTitle: '',
+            tabBarStyle: {display: 'none'},
+          })}
+           />
+      </Stack.Navigator>
+    );
+  };
 
 export default RootStack;

--- a/src/screens/TabScreen.js
+++ b/src/screens/TabScreen.js
@@ -2,7 +2,7 @@ import React, {useLayoutEffect} from "react";
 
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import {createStackNavigator} from '@react-navigation/stack';
-import {useRoute} from '@react-navigation/native';
+import {useNavigation, useRoute} from '@react-navigation/native';
 
 import { CalenderApp } from "./CalenderScreen";
 import { Chat } from "./ChatScreen";
@@ -18,8 +18,10 @@ const Tab = createBottomTabNavigator();
 const Stack = createStackNavigator();
 const CameraStack = createStackNavigator();
 const CalendarStack = createStackNavigator();
+const ChatStack = createStackNavigator();
 
 function TabNavigation() {
+  const navigation = useNavigation();
     return (
       <>
         <View style={styles.block}>  
@@ -32,8 +34,7 @@ function TabNavigation() {
             tabBarActiveTintColor: "#3B8C66",
            }}>
            <Tab.Screen
-            name="Calendar"
-            //component={CalenderStackScreen}
+            name="CalendarTab"
             component={CalenderApp}
             options={{
               tabBarIcon: ({color}) =>(
@@ -42,13 +43,20 @@ function TabNavigation() {
             }}
            />
            <Tab.Screen
-            name="Chat"
-            component={Chat}
+            name="ChatTab"
+            component={View}
+           // component={ChatStackScreen}
             options={{
               tabBarIcon: ({color}) =>(
                 <Icon name = "chat-bubble-outline" size={24} color={color} />
               ),
             }}
+            listeners = {() =>({
+              tabPress: (e) => {
+                e.preventDefault();
+                navigation.navigate("ChatScreen");
+              }
+            })}
            />  
            </Tab.Navigator>
          </View>
@@ -56,42 +64,6 @@ function TabNavigation() {
       </>
     );
 }
-/*
-//calender 화면 스택 
-//쓸 일이... 없을 것 같기도 
-const CalendarStackScreen = ({navigation, route}) => {
-  const getrouteName = async() => {
-    const routeName = await getFocusedRouteNameFromRoute(route);
-    
-    if(routeName == 'Calendar' || routeName == undefined){
-      navigation.setOptions({tabBarStyle: { display: 'flex' }});
-    }
-    else{
-      navigation.setOptions({tabBarStyle: { display: 'none' }});
-    }
-    return routeName;
-  };
-
-  useLayoutEffect(() => {
-    const routeName = getrouteName();
-  }, [navigation, route]);
-
-  return(
-    <Stack.Navigator>
-      <CalendarStack.Screen
-        name = 'Calendar'
-        options={({navigation, route}) => ({
-           tabBarStyle: { display: 'flex' }
-        })}
-        component={CalenderApp}
-      />
-    </Stack.Navigator>
-  );
-};
-
-*/
-
-//Camera 화면 스택(메뉴판 촬영/사진 선택 -> 결과 출력까지의 화면)
 
 const styles = StyleSheet.create({
   block: {


### PR DESCRIPTION
1. ChatScreen에서 하단 탭이 보이지 않게 하기 위해
ChatScreen 스택 화면으로 구현 후
Tab에서 Chat 아이콘 선택 시 navigation.navigate를 이용해 
ChatScreen으로 넘어가도록 바꿈

2. 기존에 안 보이도록 한 헤더도 다시 보이도록 (돌아가는 버튼, 그리고 추후 챗봇 이름 넣을 예정)